### PR TITLE
Return result of login process, so that it can be handled better.

### DIFF
--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -103,6 +103,7 @@ class AuthPtc(Auth):
         self.log.info('PTC User Login successful.')
 
         self.get_access_token()
+        return self._login
 
     def set_refresh_token(self, refresh_token):
         self.log.info('PTC Refresh Token provided by user')

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -85,13 +85,16 @@ class PGoApi:
 
         if proxy_config is not None:
             self._auth_provider.set_proxy(proxy_config)
-
+        
+        success = False
         if oauth2_refresh_token is not None:
-            self._auth_provider.set_refresh_token(oauth2_refresh_token)
+            success = self._auth_provider.set_refresh_token(oauth2_refresh_token)
         elif username is not None and password is not None:
-            self._auth_provider.user_login(username, password)
+            success = self._auth_provider.user_login(username, password)
         else:
             raise AuthException("Invalid Credential Input - Please provide username/password or an oauth2 refresh token")
+        
+        return success
 
     def get_position(self):
         return (self._position_lat, self._position_lng, self._position_alt)


### PR DESCRIPTION
Login process fails to be caught by PokemonGoMap because AuthProvider will always be None as accessed here:

https://github.com/PokemonGoMap/PokemonGo-Map/blob/develop/pogom/search.py#L640

Instead: I believe it is better to return the result of the login process so that this can be checked easier. Also see:
https://github.com/PokemonGoMap/PokemonGo-Map/issues/880